### PR TITLE
Provide cluster sizing info

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -99,4 +99,6 @@
         * [Getting List of Lua Extensions](api/extension-lua.md)
         * [Executing a Lua Extension](api/extension-lua-script.md)
 * [Changelog](changelog.md)
-* [Appendix: ZFS Setup Guide](zfs-guide.md)
+* Appendix
+  * [ZFS Setup Guide](zfs-guide.md)
+  * [Cluster Sizing](cluster-sizing.md)

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## TBD
 
 Documentation changes:
+ * Appendix with cluster sizing recommendations.
  * GET method for `sweep_delete` status.
 
 ## Changes in 0.11.8

--- a/cluster-sizing.md
+++ b/cluster-sizing.md
@@ -13,13 +13,13 @@ Circonus](/contact.md) if you have questions arising from your specific needs.
     storage space across the cluster.
 
 The value of `W` determines the number of nodes that can be unavailable before
-a metric data become inaccessible. A cluster with `W` write copies can survive
-`W-1` node failures before data become inaccessible.
+metric data become inaccessible. A cluster with `W` write copies can survive
+`W-1` node failures before a partial data outage will occur.
 
 Metric streams are distributed approximately evenly across the nodes in the
 cluster. In other words, each node is responsible for storing approximately
-`(T*W)/N` metric streams. For example, a cluster of 6 nodes with 100K streams
-and `W=3` would store about 50K streams per node.
+`(T*W)/N` metric streams. For example, a cluster of 4 nodes with 100K streams
+and `W=2` would store about 50K streams per node.
 
 ## Rules of Thumb
 
@@ -27,23 +27,39 @@ and `W=3` would store about 50K streams per node.
 * Favor ZFS striped mirrors over other pool layouts
 * `W` must be >= 2
 * `N` must be >= `W`
-* `W` must be >= 3 when `N` >= 6
-* `W` must be >= 4 when `N` >= 32
+* `W` should be >= 3 when `N` >= 6
+* `W` should be >= 4 when `N` >= 100
 
 ## Storage Space
 
 The system stores three types of data: text, numeric (statistical aggregates),
-and histograms. The following modeling is based on an observed distribution of
-those data elements across many clients and may be adjusted from time to time.
+and histograms. Additionally there are two tiers of data storage: near-term and
+long-term. Near-term storage is called the [raw
+database](/configuration.md#rawdatabase) and stores at full resolution (however
+frequently measurements were ingested.) Long-term resolution is determined by
+the [rollup configuration](/configuration.md#rollups).
 
-| Minimum Granularity | Storage Space / Day | Storage Space / Year |
-|:--------------------|:--------------------|:---------------------|
+The default configuration for the raw database is to collect data into shards
+of 1 week, and to retain those shards for 4 weeks before rolling them up into
+long-term storage. At 1-minute resolution, a single numeric stream would
+require approximately 118 KiB per 1-week shard, or 472 KiB total, before being
+rolled up to long-term storage.
+
+The following modeling is based on an observed distribution of all data types,
+in long-term storage, across many clients and may be adjusted from time to
+time. This would be in addition to the raw database storage above.
+
+| Minimum Resolution | Storage Space / Day | Storage Space / Year |
+|:-------------------|:--------------------|:---------------------|
 | 1 minute | 20,000 bytes | 7,170,000 bytes |
 | 5 minute | 3,800 bytes | 1,386,000 bytes |
 
+These numbers represent uncompressed data. With our default LZ4 compression
+setting in ZFS, we see 3.5x-4x compression ratios for numeric data.
+
 ## Example
 
-Suppose we want to store 100,000 metric streams at 1-minute granularity for 5
+Suppose we want to store 100,000 metric streams at 1-minute resolution for 5
 years.  We'd like to build a 4-node cluster with a `W` value of 2.
 
 ```
@@ -53,11 +69,13 @@ W=2
 
 T * 7170000 (bytes/year/stream) * 5 years = 3585000000000 bytes
 
-3585000000000 bytes / (1024*1024*1024) = 3338 GiB
+3585000000000 bytes / (1024^3) = 3338 GiB
 
-(3338 * W) / N = 1669 GiB per node
+T * 483840 (bytes/4 weeks raw/stream) / (1024^3) = 45 GiB
 
-1669 GiB / 70% utilization = 2384 GiB of usable space per node
+( (3338+45) * W) / N = 1692 GiB per node
 
-2384 GiB * 2 = 4768 GiB of raw attached storage in ZFS mirrors per node
+1692 GiB / 70% utilization = 2417 GiB of usable space per node
+
+2417 GiB * 2 = 4834 GiB of raw attached storage in ZFS mirrors per node
 ```

--- a/cluster-sizing.md
+++ b/cluster-sizing.md
@@ -1,0 +1,63 @@
+# Calculating Cluster Dimensions
+
+This is intended as a general guide to determining how many nodes and how much
+storage space per node you require for your workload. Please [contact
+Circonus](/contact.md) if you have questions arising from your specific needs.
+
+## Key Terminology
+
+* `T` is the number of unique metric streams.
+* `N` is the number of nodes participating in the cluster.
+* `W` is the number of times a given measurement is stored across the cluster.
+  * For example, if you have 1 GB of metric data, you must have `W` GB of
+    storage space across the cluster.
+
+The value of `W` determines the number of nodes that can be unavailable before
+a metric data become inaccessible. A cluster with `W` write copies can survive
+`W-1` node failures before data become inaccessible.
+
+Metric streams are distributed approximately evenly across the nodes in the
+cluster. In other words, each node is responsible for storing approximately
+`(T*W)/N` metric streams. For example, a cluster of 6 nodes with 100K streams
+and `W=3` would store about 50K streams per node.
+
+## Rules of Thumb
+
+* Nodes should be operated at no more than 70% capacity.
+* Favor ZFS striped mirrors over other pool layouts
+* `W` must be >= 2
+* `N` must be >= `W`
+* `W` must be >= 3 when `N` >= 6
+* `W` must be >= 4 when `N` >= 32
+
+## Storage Space
+
+The system stores three types of data: text, numeric (statistical aggregates),
+and histograms. The following modeling is based on an observed distribution of
+those data elements across many clients and may be adjusted from time to time.
+
+| Minimum Granularity | Storage Space / Day | Storage Space / Year |
+|:--------------------|:--------------------|:---------------------|
+| 1 minute | 20,000 bytes | 7,170,000 bytes |
+| 5 minute | 3,800 bytes | 1,386,000 bytes |
+
+## Example
+
+Suppose we want to store 100,000 metric streams at 1-minute granularity for 5
+years.  We'd like to build a 4-node cluster with a `W` value of 2.
+
+```
+T=100000
+N=4
+W=2
+
+T * 7170000 (bytes/year/stream) * 5 years = 3585000000000 bytes
+
+3585000000000 bytes / (1024*1024*1024) = 3338 GiB
+
+(3338 * W) / N = 1669 GiB per node
+
+1669 GiB / 70% utilization = 2384 GiB of usable space per node
+
+2384 GiB * 2 = 4768 GiB of raw attached storage in ZFS mirrors per node
+```

--- a/installation.md
+++ b/installation.md
@@ -13,7 +13,13 @@ expects a zpool to exist, but you do not need to create any filesystems or
 directories ahead of time. Please refer to the appendix [ZFS Setup
 Guide](/zfs-guide.md) for details and examples.
 
-Hardware requirements will necessarily vary depending upon system scale and cluster size. Please [contact us](./contact.md) with questions regarding system sizing. Circonus recommends the following minimum system specification for the single-node, free, 25K-metrics option:
+Hardware requirements will necessarily vary depending upon system scale and
+cluster size. An appendix with general guidelines for [calculating cluster
+size](/cluster-sizing.md) is provided. Please [contact us](./contact.md) with
+questions regarding system sizing.
+
+Circonus recommends the following minimum system specification for the
+single-node, free, 25K-metrics option:
 
 * 1 CPU
 * 4 GB RAM
@@ -260,9 +266,13 @@ Additional configuration is required for clusters of more than one IRONdb node. 
 
 To configure a multi-node cluster, follow these steps.
 
-#### Determine Write Copies
+#### Determine Cluster Parameters
 
-The number of write copies determines the number of nodes that can be unavailable before metric data become inaccessible. A cluster with N write copies can survive N-1 node failures before data become inaccessible. Clusters of up to 6 nodes should have a minimum of 2 write copies. Clusters of 6 or more nodes should have a minimum of 3 write copies, up to a maximum of 10.
+The number of write copies determines the number of nodes that can be
+unavailable before metric data become inaccessible. A cluster with `W` write
+copies can survive `W-1` node failures before data become inaccessible.
+Clusters of up to 6 nodes should have a minimum of 2 write copies. Clusters of
+6 or more nodes should have a minimum of 3 write copies, up to a maximum of 10.
 
 #### Create Topology Layout
 

--- a/installation.md
+++ b/installation.md
@@ -268,11 +268,17 @@ To configure a multi-node cluster, follow these steps.
 
 #### Determine Cluster Parameters
 
+The number and size of nodes you need is determined by several factors:
+ * Frequency of measurement ingestion
+ * Desired level of redundancy (write copies)
+ * Minimum granularity of rollups
+ * Retention period
+
 The number of write copies determines the number of nodes that can be
 unavailable before metric data become inaccessible. A cluster with `W` write
 copies can survive `W-1` node failures before data become inaccessible.
-Clusters of up to 6 nodes should have a minimum of 2 write copies. Clusters of
-6 or more nodes should have a minimum of 3 write copies, up to a maximum of 10.
+
+See the [appendix on cluster sizing](/cluster-sizing.md) for details.
 
 #### Create Topology Layout
 


### PR DESCRIPTION
Port of snowth sizing info from the Inside Install manual: https://login.circonus.com/resources/docs/inside/InstallSizing.html#DataStoragesizing

This does not yet include space calculation for raw DB, but note that NNTBS is largely the same as NNT, due to better compression offsetting the additional LMDB metadata.

We may want to revisit IOPS calculations which are not yet included because the old docs assumed srollup, and therefore no raw DB or NNTBS.