### PR TITLE
small issues with the docs uncovered while working on a new client

### DIFF
--- a/api/gossip-json.md
+++ b/api/gossip-json.md
@@ -38,8 +38,8 @@ The URI "/gossip/json" could yield the following example output:
 ```
     [
     {"id":"1f846f26-0cfd-4df5-b4f1-e0930604e577",
-     "gossip_time":1409082055.744880,
-     "gossip_age":0.000000,
+     "gossip_time":"1409082055.744880",
+     "gossip_age":"0.000000",
      "topo_current":"0123456789abcdef0123456789abcdef0123456789abcdef01234
     56789abcdef",
      "topo_next":"-",
@@ -51,8 +51,8 @@ The URI "/gossip/json" could yield the following example output:
       }
     },
     {"id":"765ac4cc-1929-4642-9ef1-d194d08f9538",
-     "gossip_time":1409082055.744880,
-     "gossip_age":0.000000,
+     "gossip_time":"1409082055.744880",
+     "gossip_age":"0.000000",
      "topo_current":"0123456789abcdef0123456789abcdef0123456789abcdef01234
     56789abcdef",
      "topo_next":"-",
@@ -64,8 +64,8 @@ The URI "/gossip/json" could yield the following example output:
       }
     },
     {"id":"8c2fc7b8-c569-402d-a393-db433fb267aa",
-     "gossip_time":1409082055.744880,
-     "gossip_age":0.000000,
+     "gossip_time":"1409082055.744880",
+     "gossip_age":"0.000000",
      "topo_current":"0123456789abcdef0123456789abcdef0123456789abcdef01234
     56789abcdef",
      "topo_next":"-",
@@ -77,8 +77,8 @@ The URI "/gossip/json" could yield the following example output:
       }
     },
     {"id":"07fa2237-5744-4c28-a622-a99cfc1ac87e",
-     "gossip_time":1409082055.744880,
-     "gossip_age":0.000000,
+     "gossip_time":"1409082055.744880",
+     "gossip_age":"0.000000",
      "topo_current":"0123456789abcdef0123456789abcdef0123456789abcdef01234
     56789abcdef",
      "topo_next":"-",

--- a/api/toporing-xml.md
+++ b/api/toporing-xml.md
@@ -44,7 +44,7 @@ This example retrieves a simplified topology for a 3-node cluster, assuming a we
 This example uses
 
 ```
-/toporing/json/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+/toporing/xml/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 In this example:


### PR DESCRIPTION
Small bugfixes in the documentation.  Gossip response actually uses string representations for gossip_time and gossip_age from what I have seen.  Looks also like there was a copy/paste issue in the toporing XML doc, it was referring to the json endpoint when it should be the xml endpoint in the example.