### PR TITLE
CIRC-3605 Clarify base64-encoding examples

### DIFF
--- a/tag-queries.md
+++ b/tag-queries.md
@@ -56,7 +56,7 @@ values themselves.
 
 If using regular expression patterns, the `/ /` should not be encoded. To
 perform a regex match on `(foo|bar)`, you would use the form
-`b:/KGZvb3xiYXIp/`.
+`b/KGZvb3xiYXIp/`.
 
 See the examples below for more color.
 

--- a/tag-queries.md
+++ b/tag-queries.md
@@ -50,9 +50,13 @@ enclose the query in base64 notation:
 
 `and(b"...":b"...")`
 
-To pass through the unsupported characters. If using regular expression
-patterns, the `/ /` do _not_ need to be encoded. To perform a regex match on
-`.*foo`, you would use the form `b:/Lipmb28K/`.
+To pass through the unsupported characters. Note that the asterisk (`*`) for
+glob syntax is allowed unencoded for searches, but not for tag categories or
+values themselves.
+
+If using regular expression patterns, the `/ /` should not be encoded. To
+perform a regex match on `(foo|bar)`, you would use the form
+`b:/KGZvb3xiYXIp/`.
 
 See the examples below for more color.
 

--- a/tags.md
+++ b/tags.md
@@ -30,7 +30,7 @@ To store a metric like:
 Where tilde `~`, parens `()`, and greater/less `<>` are outside of the character set you would encode
 the category and value separately as base64 and enclose them in `b""`.  For example:
 
-    foo|ST[b"fihjYXRlZ29yeSkK":b"PHZhbHVlPgo="]
+    foo|ST[b"fihjYXRlZ29yeSk=":b"PHZhbHVlPg=="]
     
 It is always safe to encode *all* incoming tags in this way, the server will decide if the name
 is safely representable without encoding and store the metric name decoded if it can.


### PR DESCRIPTION
Fix incorrect b64 strings.

Note that the asterisk character for glob searches may be sent
unencoded, even though it is disallowed for tag categories and values.