### PR TITLE
Document intended behavior of the read-text

### DIFF
--- a/api/read-text.md
+++ b/api/read-text.md
@@ -1,8 +1,6 @@
 # Retrieving Text Data
 
-This API call is for retrieving text data from the Snowth cluster. It will return an array with all the timestamps from the time given, along with the attendant data.
-
-Data will be returned in an array of tuples. Each tuple will contain a timestamp that indicates when the text value was received (given in milliseconds since the epoch), as well as the text value itself.
+This API call is for retrieving text data from the Snowth cluster.
 
 ## Description
 
@@ -25,6 +23,14 @@ GET
  * `uuid` : The UUID of the check to which the metric belongs.
  * `metric` : The name of the metric for which to pull data.
 
+### Output
+
+The response payload will contain a JSON array of tuples consisting of the timestamps (in millisecions since epoch) from the time the value was received, and the text value itself as a string.
+
+The first value of the response array is an exception to this rule.
+It will contain the timestamp of the start parameter, along with the text value at the start time.
+This is done, so that the user has information about the initial state of the text metric for the request interval.
+
 ## Examples
 
 ```
@@ -42,5 +48,5 @@ In this example:
 ### Example 1 Output
 
 ```json
-[[1380000000555,"test_value"],[1380000300123,"test_value_2"]]
+[[1380000000000,"test_value_at_the_beginning_of_the_requested_range"],[1380000000123,"test_value_2"]]
 ```

--- a/api/read-text.md
+++ b/api/read-text.md
@@ -25,7 +25,7 @@ GET
 
 ### Output
 
-The output will be a JSON array, the entries of which are JSON arrays which indicate change points of the text metrics, containing two values:
+The output will be a JSON array, the entries of which are JSON arrays which indicate change-points of the text metric, containing two values:
 The timestamps of the change-point in milliseconds since the epoch, and the new value as a string.
 
 The first entry will be the last change point **before** the requested start time.

--- a/api/read-text.md
+++ b/api/read-text.md
@@ -25,7 +25,7 @@ GET
 
 ### Output
 
-The output will be a JSON array, the entries of which are JSON arrays with two values:
+The output will be a JSON array, the entries of which are JSON arrays which indicate change points of the text metrics, containing two values:
 The timestamps of the change-point in milliseconds since the epoch, and the new value as a string.
 
 The first entry will be the latest change point **before** the requested start time.

--- a/api/read-text.md
+++ b/api/read-text.md
@@ -25,14 +25,12 @@ GET
 
 ### Output
 
-The output will be a JSON array, with the following values:
-
-The first value will be a JSON array containing two values:
-The timestamp of the start parameter of the request in milliseconds since the epoch, and the value of the text metric at that point in time as a string.
-
-Subsequent values will indicate the change points of the text metric.
-Those will also be JSON arrays containing two values:
+The output will be a JSON array, the entries of which are JSON arrays with two values:
 The timestamps of the change-point in milliseconds since the epoch, and the new value as a string.
+
+The first entry will be the latest change point **before** the requested start time.
+
+Subsequent entries will be change points within the requested period.
 
 ## Examples
 
@@ -51,5 +49,5 @@ In this example:
 ### Example 1 Output
 
 ```json
-[[1380000000000,"value_at_the_beginning_of_the_requested_range"],[1380000000123,"value_2"],[1380000000125,"value_3"]]
+[[1379232000000,"value_1"],[1380000000123,"value_2"],[1380000000125,"value_3"]]
 ```

--- a/api/read-text.md
+++ b/api/read-text.md
@@ -28,7 +28,7 @@ GET
 The output will be a JSON array, the entries of which are JSON arrays which indicate change points of the text metrics, containing two values:
 The timestamps of the change-point in milliseconds since the epoch, and the new value as a string.
 
-The first entry will be the latest change point **before** the requested start time.
+The first entry will be the last change point **before** the requested start time.
 
 Subsequent entries will be change points within the requested period.
 

--- a/api/read-text.md
+++ b/api/read-text.md
@@ -25,11 +25,14 @@ GET
 
 ### Output
 
-The response payload will contain a JSON array of tuples consisting of the timestamps (in millisecions since epoch) from the time the value was received, and the text value itself as a string.
+The output will be a JSON array, with the following values:
 
-The first value of the response array is an exception to this rule.
-It will contain the timestamp of the start parameter, along with the text value at the start time.
-This is done, so that the user has information about the initial state of the text metric for the request interval.
+The first value will be a JSON array containing two values:
+The timestamp of the start parameter of the request in milliseconds since the epoch, and the value of the text metric at that point in time as a string.
+
+Subsequent values will indicate the change points of the text metric.
+Those will also be JSON arrays containing two values:
+The timestamps of the change-point in milliseconds since the epoch, and the new value as a string.
 
 ## Examples
 
@@ -48,5 +51,5 @@ In this example:
 ### Example 1 Output
 
 ```json
-[[1380000000000,"test_value_at_the_beginning_of_the_requested_range"],[1380000000123,"test_value_2"]]
+[[1380000000000,"value_at_the_beginning_of_the_requested_range"],[1380000000123,"value_2"],[1380000000125,"value_3"]]
 ```


### PR DESCRIPTION
Note that the second timestamp of the example response was later than the requested range.