### PR TITLE
Make Appendices toggle-able

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -130,7 +130,7 @@
         * [Executing a Lua Extension](api/extension-lua-script.md)
         * [Issuing CAQL Queries](api/extension-caql.md)
 * [Changelog](changelog.md)
-* Appendices
+* [Appendices](appendices.md)
   * [ZFS Setup Guide](zfs-guide.md)
   * [Cluster Sizing](cluster-sizing.md)
   * [Deprecated APIs](deprecated-apis.md) <!-- please keep this as the last appendix -->

--- a/appendices.md
+++ b/appendices.md
@@ -1,0 +1,7 @@
+# Appendices
+
+---
+
+* [ZFS Setup Guide](zfs-guide.md)
+* [Cluster Sizing](cluster-sizing.md)
+* [Deprecated APIs](deprecated-apis.md)


### PR DESCRIPTION
The chapter toggle plugin does not handle non-link headings.
Make the Appendices item a link with a summary page, so that one may
expand it and see its children in the left menu.