### PR TITLE
Additional rebalance details

### DIFF
--- a/resizing-clusters.md
+++ b/resizing-clusters.md
@@ -12,11 +12,6 @@ metric stream, and then sending that stream to the new owning node. All metric
 data remain available during a rebalance, under the old topology. New,
 incoming metric data is replicated to _both_ old and new topologies.
 
-Because of the consistent-hashing design of IRONdb, metric ownership changes
-are limited to transitions from existing cluster nodes to new ones. Changes
-between existing nodes are not possible in non-sided topologies. There is a low
-probability of existing nodes exchanging metrics in sided topologies.
-
 After all nodes complete the rebalance, they will switch their active topology
 from old to new. Each node will then kick off a delete operation of any
 metrics that no longer belong on that node.

--- a/resizing-clusters.md
+++ b/resizing-clusters.md
@@ -13,8 +13,7 @@ data remain available during a rebalance, under the old topology. New,
 incoming metric data is replicated to _both_ old and new topologies.
 
 After all nodes complete the rebalance, they will switch their active topology
-from old to new. Each node will then kick off a delete operation of any
-metrics that no longer belong on that node.
+from old to new.
 
 A helper tool exists to simplify the procedure, and its use is illustrated
 below. Both additions and removals may be performed in the same operation,

--- a/resizing-clusters.md
+++ b/resizing-clusters.md
@@ -56,6 +56,11 @@ the closing `</snowth>` line:
 This will make the overall operation take longer to complete, but should avoid
 overwhelming the incoming node(s).
 
+This value will only take effect at the start of a rebalance operation, and
+will be ignored if changed while a rebalance is ongoing. To abandon a rebalance
+operation, see the last item of either [Adding Nodes](#adding-nodes) or
+[Removing Nodes](#removing-nodes) below.
+
 ## Adding Nodes
 
 An existing IRONdb cluster has two nodes with write factor of 2. A new node is

--- a/resizing-clusters.md
+++ b/resizing-clusters.md
@@ -97,23 +97,20 @@ this with the `-h` option for details on the available options.
 
   ```curl http://<node>:<api-port>/rebalance/state```
 
-* To abort the rebalance, POST to `/rebalance/deactivate/[new topology hash]`
+* To abort the rebalance, [stop the IRONdb service](/operations.md#service-management) and remove the rebalance state file:
 
-  ```curl -X POST http://<node>:<api-port>/rebalance/deactivate/c790e663badf603ac555e02a07bf195f06932f271ee1f2d7fae104b3a1b232f3```
+  ```/irondb/localstate/.rebalance_state.json```
 
-  on every node, including any new nodes that were added.
+  on every node, including on any new nodes that were added. Then start the
+  service again.
 
 ## Removing Nodes
 
 Shrinking a cluster is basically the same as adding, above:
 * Create a new topology with the nodes that should remain.
-* Load the new topology to the nodes that should remain.
-* Start rebalance to new topology on the nodes that should remain.
-
-One difference is that nodes that are not in the new topology do not
-automatically clean up their data, which avoids delaying the cleanup phase
-unnecessarily. It is up to the operator to do this as part of decommissioning
-the unused nodes.
+* Load the new topology to all nodes, including the ones that are leaving.
+* Start rebalance to new topology on all nodes, including the ones that are
+  leaving.
 
 We will use the cluster resizing tool, `/opt/circonus/bin/resize_cluster`. Run
 this with the `-h` option for details on the available options.
@@ -143,8 +140,8 @@ this with the `-h` option for details on the available options.
 
   ```curl http://<node>:<api-port>/rebalance/state```
 
-* To abort the rebalance, POST to `/rebalance/deactivate/[new topology hash]`
+* To abort the rebalance, [stop the IRONdb service](/operations.md#service-management) and remove the rebalance state file:
 
-  ```curl -X POST http://<node>:<api-port>/rebalance/deactivate/c790e663badf603ac555e02a07bf195f06932f271ee1f2d7fae104b3a1b232f3```
+  ```/irondb/localstate/.rebalance_state.json```
 
-  on every node that is part of the new topology.
+  on every node, including on any leaving nodes. Then start the service again.


### PR DESCRIPTION
Clarify that metrics rarely, if ever, move between existing nodes during a rebalance.

Note how to force sequential rebalance if the incoming node(s) can't handle receiving data from all existing nodes at once.